### PR TITLE
hotfix: extract tests

### DIFF
--- a/libs/langchain-tavily/src/tests/extract.test.ts
+++ b/libs/langchain-tavily/src/tests/extract.test.ts
@@ -37,8 +37,8 @@ describe("TavilyExtract", () => {
 
     expect(tool.name).toBe("custom_extract");
     expect(tool.description).toBe("Custom description");
-    expect(tool.extractDepthDefault).toBe("advanced");
-    expect(tool.includeImagesDefault).toBe(true);
+    expect(tool.extractDepth).toBe("advanced");
+    expect(tool.includeImages).toBe(true);
   });
 
   test("initializes with custom apiWrapper", () => {


### PR DESCRIPTION
This pull request includes a minor update to the `libs/langchain-tavily/src/tests/extract.test.ts` file. The change updates property names in the test assertions to match the updated naming conventions in the codebase.

Test updates:

* Updated property names in the `TavilyExtract` test suite from `extractDepthDefault` to `extractDepth` and from `includeImagesDefault` to `includeImages`.