### PR TITLE
Langchain js client source

### DIFF
--- a/libs/providers/langchain-tavily/src/utils.ts
+++ b/libs/providers/langchain-tavily/src/utils.ts
@@ -1,6 +1,7 @@
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 const TAVILY_BASE_URL = "https://api.tavily.com";
+const TAVILY_CLIENT_SOURCE = "langchain-js";
 
 /**
  * The parameters for the Tavily Search API.
@@ -719,6 +720,7 @@ export class TavilySearchAPIWrapper extends BaseTavilyAPIWrapper {
     const headers = {
       Authorization: `Bearer ${this.tavilyApiKey}`,
       "Content-Type": "application/json",
+      "X-Client-Source": TAVILY_CLIENT_SOURCE,
     };
 
     // Convert camelCase to snake_case for API compatibility
@@ -756,6 +758,7 @@ export class TavilyExtractAPIWrapper extends BaseTavilyAPIWrapper {
     const headers = {
       Authorization: `Bearer ${this.tavilyApiKey}`,
       "Content-Type": "application/json",
+      "X-Client-Source": TAVILY_CLIENT_SOURCE,
     };
 
     const apiParams = this.convertCamelToSnakeCase(params);
@@ -789,6 +792,7 @@ export class TavilyCrawlAPIWrapper extends BaseTavilyAPIWrapper {
     const headers = {
       Authorization: `Bearer ${this.tavilyApiKey}`,
       "Content-Type": "application/json",
+      "X-Client-Source": TAVILY_CLIENT_SOURCE,
     };
 
     const apiParams = this.convertCamelToSnakeCase(params);
@@ -822,6 +826,7 @@ export class TavilyMapAPIWrapper extends BaseTavilyAPIWrapper {
     const headers = {
       Authorization: `Bearer ${this.tavilyApiKey}`,
       "Content-Type": "application/json",
+      "X-Client-Source": TAVILY_CLIENT_SOURCE,
     };
 
     const apiParams = this.convertCamelToSnakeCase(params);
@@ -859,6 +864,7 @@ export class TavilyResearchAPIWrapper extends BaseTavilyAPIWrapper {
     const headers = {
       Authorization: `Bearer ${this.tavilyApiKey}`,
       "Content-Type": "application/json",
+      "X-Client-Source": TAVILY_CLIENT_SOURCE,
     };
 
     const apiParams = this.convertCamelToSnakeCase(params);
@@ -924,6 +930,7 @@ export class TavilyResearchAPIWrapper extends BaseTavilyAPIWrapper {
     const headers = {
       Authorization: `Bearer ${this.tavilyApiKey}`,
       "Content-Type": "application/json",
+      "X-Client-Source": TAVILY_CLIENT_SOURCE,
     };
 
     const response = await fetch(`${this.apiBaseUrl}/research/${requestId}`, {


### PR DESCRIPTION
<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations. You must include tests (if applicable) and documentation for your integration:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

This PR adds the `X-Client-Source` HTTP header to all outgoing Tavily API requests within the LangChain.js integration.

This change standardizes the tracking of integration usage, setting the `client_source` to `"langchain-js"`. Since the LangChain.js Tavily integration uses custom API wrappers instead of the official Tavily JS SDK, the `X-Client-Source` header is manually added to each API call.

No breaking changes are expected as this is an additive modification for internal usage tracking.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

---
<a href="https://cursor.com/background-agent?bcId=bc-35b862bc-287b-4f57-b513-aad8a30d2127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35b862bc-287b-4f57-b513-aad8a30d2127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

